### PR TITLE
Support Python 3 Runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.mypy_cache


### PR DESCRIPTION
Fix `pycheckers.py` so that it will run in either Python 2 or Python 3.
(Requires Python 3.3+.)

This is to accommodate situations where Python 3 is installed as the default `python` in `PATH` (e.g., in virtual environments).

This was tested by hand via:

```
$ git clone git@github.com:posita/flycheck-pycheckers.git
…
$ mkvirtualenv -a …/flycheck-pycheckers --python=python3.6 …
…
$ python --version
Python 3.6.0
$ pip install flake8 pylint mypy
…
$ …/flycheck-pycheckers/bin/pycheckers.py …/flycheck-pycheckers/bin/pycheckers.py
WARNING C0301:pylint: Line too long (85/80)  ("line-too-long") at bin/pycheckers.py line 77,0.
WARNING C0301:pylint: Line too long (96/80)  ("line-too-long") at bin/pycheckers.py line 145,0.
WARNING C0301:pylint: Line too long (93/80)  ("line-too-long") at bin/pycheckers.py line 170,0.
WARNING C0301:pylint: Line too long (95/80)  ("line-too-long") at bin/pycheckers.py line 172,0.
WARNING C0301:pylint: Line too long (84/80)  ("line-too-long") at bin/pycheckers.py line 181,0.
WARNING C0301:pylint: Line too long (83/80)  ("line-too-long") at bin/pycheckers.py line 359,0.
WARNING C0301:pylint: Line too long (83/80)  ("line-too-long") at bin/pycheckers.py line 548,0.
WARNING C0301:pylint: Line too long (86/80)  ("line-too-long") at bin/pycheckers.py line 640,0.
WARNING C0301:pylint: Line too long (85/80)  ("line-too-long") at bin/pycheckers.py line 641,0.
WARNING C0301:pylint: Line too long (85/80)  ("line-too-long") at bin/pycheckers.py line 642,0.
$ mkvirtualenv -a …/flycheck-pycheckers --python=python2.7 …
…
$ python --version
Python 2.7.13
$ pip install flake8 pylint
…
$ …/flycheck-pycheckers/bin/pycheckers.py …/flycheck-pycheckers/bin/pycheckers.py
WARNING C0301:pylint: Line too long (85/80)  ("line-too-long") at bin/pycheckers.py line 77,0.
WARNING C0301:pylint: Line too long (96/80)  ("line-too-long") at bin/pycheckers.py line 145,0.
WARNING C0301:pylint: Line too long (93/80)  ("line-too-long") at bin/pycheckers.py line 170,0.
WARNING C0301:pylint: Line too long (95/80)  ("line-too-long") at bin/pycheckers.py line 172,0.
WARNING C0301:pylint: Line too long (84/80)  ("line-too-long") at bin/pycheckers.py line 181,0.
WARNING C0301:pylint: Line too long (83/80)  ("line-too-long") at bin/pycheckers.py line 359,0.
WARNING C0301:pylint: Line too long (83/80)  ("line-too-long") at bin/pycheckers.py line 548,0.
WARNING C0301:pylint: Line too long (86/80)  ("line-too-long") at bin/pycheckers.py line 640,0.
WARNING C0301:pylint: Line too long (85/80)  ("line-too-long") at bin/pycheckers.py line 641,0.
WARNING C0301:pylint: Line too long (85/80)  ("line-too-long") at bin/pycheckers.py line 642,0.
WARNING : mypy:Checker not found on PATH, unable to check at bin/pycheckers.py line 1.
WARNING : mypy:Checker not found on PATH, unable to check at bin/pycheckers.py line 1.
```