### PR TITLE
Add checkers: pylint-py3k & pylint3 (Only accept if pull request #25 is discarded)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This package provides a way to run multiple syntax checkers on Python code,
 in parallel.  The list of supported checkers includes:
 
 - [pylint](https://www.pylint.org/)
+- [pylint-py3k](https://www.pylint.org/) (Command: pylint --py3k)
+- [pylint3](https://www.pylint.org/)
 - [flake8](http://flake8.pycqa.org/)
 - [pep8](https://www.python.org/dev/peps/pep-0008/)
 - [pyflakes](https://github.com/PyCQA/pyflakes)
@@ -135,7 +137,7 @@ Note that these are implemented as modifying the values received by
   For example, a directory containing auto-generated code may omit various
   warnings about indentation or code style.
 * `pylint_rcfile` - the location of a project-specific configuration file
-  for pylint
+  for pylint, pylint-py3k, pylint3
 * `mypy_config_file` - the location of a project-specific configuration file
   for mypy
 * `flake8_config_file` - the location of a project-specific configuration file

--- a/bin/pycheckers.py
+++ b/bin/pycheckers.py
@@ -507,6 +507,8 @@ class PylintRunner(LintRunner):
     def get_run_flags(self, _filepath):
         # type: (str) -> Iterable[str]
         args = []
+        if self.name == 'pylint-py3k':
+            args.append('--py3k')
         if self.ignore_codes is not None:
             args.append('--disable=' + ','.join(self.ignore_codes))
         args += [
@@ -533,6 +535,30 @@ class PylintRunner(LintRunner):
         # type: (int) -> bool
         # https://docs.pylint.org/en/1.6.0/run.html, pylint returns a bit-encoded exit code.
         return not (returncode & 1 or returncode & 32)
+
+
+class PylintPy3kRunner(PylintRunner):
+    """Run pylint --py3k, producing flymake readable output.
+
+    Run pylint in Python 3 porting mode, all checkers will be disabled
+    and only messages emitted by the porting checker will be displayed
+
+    See: PylintRunner
+    """
+
+    @property
+    def name(self):
+        # type: () -> str
+        return 'pylint-py3k'
+
+
+class Pylint3Runner(PylintRunner):
+    """Run pylint3, producing flymake readable output.
+
+    See: PylintRunner
+    """
+
+    command = 'pylint3'
 
 
 class MyPy2Runner(LintRunner):
@@ -679,6 +705,8 @@ RUNNERS = {
     'flake8': Flake8Runner,
     'pep8': Pep8Runner,
     'pylint': PylintRunner,
+    'pylint-py3k': PylintPy3kRunner,
+    'pylint3': Pylint3Runner,
     'mypy2': MyPy2Runner,
     'mypy3': MyPy3Runner,
     'bandit': BanditRunner,
@@ -901,7 +929,7 @@ def parse_args():
                               '(not using virtualenvwrapper) virtualenv.'))
     parser.add_argument('--pylint-rcfile', default=None,
                         dest='pylint_rcfile',
-                        help='Location of a config file for pylint')
+                        help='Location of a config file for pylint, pylint-py3k, pylint3')
     parser.add_argument('--mypy-config-file', default=None,
                         dest='mypy_config_file',
                         help='Location of a config file for mypy')

--- a/flycheck-pycheckers.el
+++ b/flycheck-pycheckers.el
@@ -28,6 +28,8 @@
 ;; in parallel.  The list of supported checkers includes:
 ;;
 ;; - pylint
+;; - pylint-py3k (Command: pylint --py3k)
+;; - pylint3
 ;; - flake8
 ;; - pep8
 ;; - pyflakes
@@ -151,7 +153,7 @@
 ;;   warnings about indentation or code style.
 ;;
 ;; * `pylint_rcfile' - the location of a project-specific configuration file
-;;   for pylint
+;;   for pylint, pylint-py3k, pylint3
 ;;
 ;; * `mypy_config_file' - the location of a project-specific configuration file
 ;;   for mypy
@@ -179,6 +181,8 @@
   "The set of enabled checkers to run."
   :type '(set
           (const :tag "pylint" pylint)
+          (const :tag "pylint-py3k" pylint-py3k)
+          (const :tag "pylint3" pylint3)
           (const :tag "PEP8" pep8)
           (const :tag "flake8" flake8)
           (const :tag "pyflakes" pyflakes)


### PR DESCRIPTION
Stuff relevant primary during migration to Python 3 added

* Added checkers:
** pylint-py3k (Command: pylint --py3k)
** pylint3

I think it is relevant to also check with pylint3 while preparing and
during migration from Python 2 to 2+3 or 3.

pylint --py3k might also show some things to fix, so that have also
been added.

Option pylint_rcfile is common for all pylint* commands, just as for mypy*.

Note: README.md is updated manually, since generating it using
el2markdown, generates a lot of changes.