### PR TITLE
Fix mypy --shadow-file parameter order

### DIFF
--- a/bin/pycheckers.py
+++ b/bin/pycheckers.py
@@ -603,7 +603,7 @@ class MyPy2Runner(LintRunner):
         # https://github.com/msherry/flycheck-pycheckers/issues/2, so we can
         # respect per-file mypy.ini config options
         # TODO: only do this when being run by flycheck?
-        flags += ['--shadow-file', filepath, original_filepath]
+        flags += ['--shadow-file', original_filepath, filepath]
         return flags
 
     def fixup_data(self, _line, data, filepath):


### PR DESCRIPTION
Mypy has the following documentation for the --shadow-file parameter:

```
  --shadow-file SOURCE_FILE SHADOW_FILE
                            When encountering SOURCE_FILE, read and type check
                            the contents of SHADOW_FILE instead.
```

In the context of the modified code `filepath` is the temporary file and `original_filepath` is the path of the buffer being edited. We want the temporary file sorted in `filepath` to be the SHADOW_FILE.

This fixes the issue where mypy checks only take effect after saving.
