### PR TITLE
Add I to valid error types for Flake8 (supports isort plugin)

### DIFF
--- a/bin/pycheckers.py
+++ b/bin/pycheckers.py
@@ -525,7 +525,7 @@ class Flake8Runner(LintRunner):
         r'(?P<filename>[^:]+):'
         '(?P<line_number>[^:]+):'
         '(?P<column_number>[^:]+): '
-        '(?P<error_type>[WEFCN])(?P<error_number>[^ ]+) '
+        '(?P<error_type>[WEFCNI])(?P<error_number>[^ ]+) '
         '(?P<description>.+)$')
 
     version_matcher = re.compile(


### PR DESCRIPTION
We use [flake8-isort](https://pypi.org/project/flake8-isort/) which outputs warnings like this:

```
/q/os-core/spaces/models.py:2:1: I003 isort expected 1 blank line in imports, found 0
/q/os-core/spaces/models.py:6:1: I003 isort expected 1 blank line in imports, found 0
/q/os-core/spaces/models.py:7:1: I001 isort found an import in the wrong position
/q/os-core/spaces/models.py:8:1: I001 isort found an import in the wrong position
```