### PR TITLE
Match default line length with checkers' default

### DIFF
--- a/bin/pycheckers.py
+++ b/bin/pycheckers.py
@@ -1031,7 +1031,7 @@ def parse_args():
                         default='',
                         help="Comma-separated list of error codes to ignore")
     parser.add_argument('--max-line-length', dest='max_line_length',
-                        default=80, action='store',
+                        default=79, action='store',
                         help='Maximum line length')
     parser.add_argument('--no-merge-configs', dest='merge_configs',
                         action='store_false',

--- a/flycheck-pycheckers.el
+++ b/flycheck-pycheckers.el
@@ -214,7 +214,7 @@ for example.  Can be further customized via the \".pycheckers\"
 config file."
   :type '(repeat :tag "Codes" (string :tag "Error/Warning code")))
 
-(flycheck-def-option-var flycheck-pycheckers-max-line-length 80
+(flycheck-def-option-var flycheck-pycheckers-max-line-length 79
   python-pycheckers
   "The maximum line length allowed by the checkers."
   :type 'integer)


### PR DESCRIPTION
This PR addresses issue #35, by ensuring the default configuration for line-length in pycheckers matches what checkers (and PEP8 spec) use by default.