### PR TITLE
feat(bandit): Use .bandit, if it exists

### DIFF
--- a/bin/pycheckers.py
+++ b/bin/pycheckers.py
@@ -838,6 +838,10 @@ class BanditRunner(LintRunner):
     def get_run_flags(self, _filepath):
         # type: (str) -> Iterable[str]
         flags = ['-f', 'csv']
+        config_file = self.find_config_file('bandit_config_file', ['.bandit'])
+        if config_file:
+            flags += ['--ini', config_file]
+
         if self.ignore_codes is not None:
             # NOTE: this doesn't work if the code isn't recognized as a bandit
             # code (e.g. pylint errors)


### PR DESCRIPTION
I've been modifying [my .emacs.d copy of this file](https://github.com/captain-kark/.emacs.d/commits/mac/elpa/flycheck-pycheckers-20190308.1915/bin/pycheckers.py) for a while now, I think some of it could be useful.