### PR TITLE
fix(project_root): Prefer venv as root over vcs

### DIFF
--- a/bin/pycheckers.py
+++ b/bin/pycheckers.py
@@ -233,20 +233,19 @@ class LintRunner(object):
         # type: (str, str) -> str
         """Find the root directory of the current project.
 
-        1. Walk up the directory tree looking for a VCS directory.
-        2. Failing that, find a virtualenv that matches a part of the
-               directory, and choose that as the root.
+        1. Find a virtualenv that matches a part of the directory, and choose that.
+        2. Failing that, walk up the directory tree looking for a VCS directory.
         3. Otherwise, just use the local directory.
         """
         # Case 1
-        vcs_root, _vcs_name = find_vcs_root(source_file)
-        if vcs_root:
-            return vcs_root
-
-        # Case 2
         project_dir, _venv_path = guess_virtualenv(source_file, venv_root)
         if project_dir:
             return project_dir
+
+        # Case 2
+        vcs_root, _vcs_name = find_vcs_root(source_file)
+        if vcs_root:
+            return vcs_root
 
         # Case 3
         return os.path.dirname(source_file)


### PR DESCRIPTION
If you use pyenv and set `flycheck-pycheckers-venv-root` to `"~/.pyenv/versions/"`, you can get a lot more use out of the root project detection features by preferring the virtual environment directory over the vcs one.