### PR TITLE
Added support for MyPy daemon mode.

### DIFF
--- a/bin/pycheckers.py
+++ b/bin/pycheckers.py
@@ -1126,7 +1126,7 @@ def parse_args():
                         ' a static set of python files/dirs to be operated on'
                         ' (see --mypy-daemon-files-command).')
     parser.add_argument('--mypy-daemon-files-command',
-                        default='find tools -name "*.py"', action='store',
+                        default='find . -name "*.py"', action='store',
                         help='A shell command to run to generate the list of'
                         ' python files/dirs for the mypy daemon.'
                         ' Mypy in daemon mode will only process files included'


### PR DESCRIPTION
We had briefly chatted about adding this feature a number of months back, and I finally had a bit time to take a whirl at it.

I added two arguments to pycheckers.py:

**--mypy-use-daemon**
Enables daemon mode. It is disabled by default, in which case behavior remains unchanged from before.

**--mypy-daemon-files-command**
A shell command to execute to provide the MyPy daemon with a list of files/dirs relative to the project root.  Defaults to simply "echo ."  The MyPy daemon isn't able to follow imports, so the whole working set of files has to be passed to it; not simply the one being inspected.  Holler if you think there'd be a more preferable way to handle this.

One slight downside with daemon mode is that, since the process is persistent and shared, it doesn't see the temp flycheck_xxx files so only checks against what is saved to disk.  (personally I've got flycheck set to run only on save so this isn't a problem, but could be annoying for others). 

Anyway, hopefully this is useful.

