### PR TITLE
Fix for issue #45.

### DIFF
--- a/bin/pycheckers.py
+++ b/bin/pycheckers.py
@@ -966,7 +966,7 @@ def update_options_locally(options):
                 # Special case config files to contain the full path - assume
                 # the specified path is absolute, or relative to the current
                 # .pycheckers file
-                if 'config_file' in key:
+                if 'config_file' in key or 'rcfile' in key:
                     if not os.path.isabs(value):
                         value = os.path.join(os.path.dirname(config_file_path), value)
                 # Allow for extending, rather than replacing, ignore codes


### PR DESCRIPTION
Localize the pylint configuration file with an absolute pathname.  Previously this was not done because of an issue with detecting the key.