### PR TITLE
feat(mypy): Hint for files existing outside project directory

### DIFF
--- a/bin/pycheckers.py
+++ b/bin/pycheckers.py
@@ -766,6 +766,15 @@ class MyPy2Runner(LintRunner):
         config_file = self.find_config_file('mypy_config_file', ['mypy.ini'])
         if config_file:
             flags += ['--config-file', config_file]
+            mypy_config = ConfigParser()
+            mypy_config.read(config_file)
+            if mypy_config.has_option('mypy', 'mypy_path'):
+                # contextual source for mypy, useful when tests are outside module definition
+                for mypy_path in mypy_config.get('mypy', 'mypy_path').replace(':', ',').split(','):
+                    try:
+                        os.path.dirname(original_filepath).index(os.path.join(os.path.dirname(config_file), mypy_path))
+                    except ValueError:
+                        flags.append(mypy_path)
 
         if self.options.mypy_no_implicit_optional:
             flags += ['--no-implicit-optional']


### PR DESCRIPTION
I am working in a project where all tests are placed in a sibling directory
next to the main project's source root.

```
cd ./some_project
tree
├── Makefile
├── README.md
├── some_project
│   ├── __init__.py
│   └── __main__.py
├── mypy.ini
├── pytest.ini
├── requirements-frozen.txt
├── requirements.txt
└── tests
    ├── conftest.py
    └── unit_tests
        ├── some_feature
        │   ├── test_foo.py
        │   └── test_bar.py
        └── test_baz.py
```

If you include a `mypy_path` in `mypy.ini` pointing to your current project,
when combined with `find_project_root`, a check can be made to use your
project's existing mypy type definitions while editing code in the `tests`
directory.

When editing code that matches a directory that shares its base with
a `mypy_path`, nothing is done since it is already in mypy's context.