### PR TITLE
feat(mypy): Support mypy cache in nested modules

### DIFF
--- a/bin/pycheckers.py
+++ b/bin/pycheckers.py
@@ -730,11 +730,10 @@ class MyPy2Runner(LintRunner):
         under a subdir corresponding to the branch name.
         """
         branch_top = os.path.join(project_root, '.mypy_cache', 'branches')
-        # It doesn't make sense to get a branch name unless we actually found a
-        # VCS root (i.e. a virtualenv match isn't enough)
-        branch = ''                       # type: Optional[str]
-        if find_vcs_name(project_root):
-            branch = get_vcs_branch_name(project_root)
+        branch = ''  # type: Optional[str]
+        vcs_root = find_vcs_root(project_root)[0]
+        if vcs_root:
+            branch = get_vcs_branch_name(vcs_root)
         if branch:
             cache_dir = os.path.join(branch_top, branch)
         else:


### PR DESCRIPTION
I am working on a project that started as a docker image definition,
and has evolved to include a python module in a directory beneath the
top-level root.

```
cd dockerfile_thing
tree .
.
├── .git
│   └── [ ... ]
├── configs
│   ├── foo.json
│   └── bar.txt
├── image-builder-utility
│   ├── script.sh
│   └── README.md
├── python_module_thing
│   ├── .venv
│   │   └── [ ... ]
│   ├── README.md
│   ├── Makefile
│   ├── project_root
│   │   ├── __init__.py
│   │   └── __main__.py
│   └── requirements.txt
├── some-docker-image
│   ├── Dockerfile
│   └── README.md
└── README.md
```

This will allow for the `python_module_thing` mypy cache to populate in
the correct directory, using the current branch name found in the base
project's `.git` directory. Otherwise, `HEAD` is always used.