### PR TITLE
Do not require inferred executable names to be on PATH if overriding

### DIFF
--- a/bin/pycheckers.py
+++ b/bin/pycheckers.py
@@ -22,7 +22,7 @@ from csv import DictReader
 from distutils.version import LooseVersion
 from functools import partial
 import shlex
-from subprocess import PIPE, Popen, call
+from subprocess import PIPE, Popen
 
 # TODO: Ignore the type of conditional imports until
 # https://github.com/python/mypy/issues/1107 is fixed
@@ -39,7 +39,7 @@ try:
     # pylint: disable=unused-import, ungrouped-imports
     from argparse import Namespace
     from typing import (
-        Any, Dict, List, IO, Iterable, Optional, Set, Tuple, Union)
+        Any, Dict, List, Iterable, Optional, Set, Tuple, Union)
 except ImportError:
     pass
 
@@ -320,10 +320,7 @@ class LintRunner(object):
         E.g. if there is a company-provided script to run mypy, allow users to
         use that instead of the mypy executable directly.
         """
-        parts = None
-        command_line_option_name = '{}_command'.format(self.name)
-        if hasattr(self.options, command_line_option_name):
-            parts = shlex.split(getattr(self.options, command_line_option_name))
+        parts = self._user_defined_command_parts()
 
         if not parts:
             return parts
@@ -413,10 +410,26 @@ class LintRunner(object):
                         errors_or_warnings += 1
         return errors_or_warnings, out_lines
 
+    def _user_defined_command_parts(self):
+        # type: () -> List[str]
+        parts = None
+        command_line_option_name = '{}_command'.format(self.name)
+        if hasattr(self.options, command_line_option_name):
+            parts = shlex.split(getattr(self.options, command_line_option_name))
+
+        return parts
+
     def _executable_exists(self):
         # type: () -> bool
         # https://stackoverflow.com/a/6569511/52550
-        args = ['/usr/bin/env', 'which', self.command]
+        args = ['/usr/bin/env', 'which']
+        user_cmd_line = self._user_defined_command_parts()
+        if user_cmd_line:
+            user_executable = user_cmd_line[0]
+            args.append(user_executable)
+        else:
+            args.append(self.command)
+
         try:
             process = Popen(args, stdout=PIPE, stderr=PIPE)
         except Exception as e:                   # pylint: disable=broad-except
@@ -424,9 +437,7 @@ class LintRunner(object):
             return False
         exec_path, _err = process.communicate()
 
-        args = ['[', '-x', exec_path.strip(), ']']
-        retcode = call(args)
-        return retcode == 0
+        return bool(exec_path) and process.returncode == 0
 
     def run(self, filepath):
         # type: (str) -> Tuple[int, List[str]]
@@ -464,7 +475,12 @@ class LintRunner(object):
             self.debug('{} command: {}'.format(self.name, ' '.join(args)))
             process = Popen(
                 args, stdout=PIPE, stderr=PIPE, universal_newlines=True,
-                env=dict(os.environ, **self.get_env_vars()))
+                env=dict(os.environ, **self.get_env_vars()),
+                # shell=False is required because we assume that the first arg is the executable,
+                # which isn't necessarily the case when we're invoking via the shell (e.g.,
+                # "OTHERWISE_UNSET_ENV_VAR=this-will-show-up-in-the-output /usr/bin/env")
+                shell=False,
+            )
         except Exception as e:                   # pylint: disable=broad-except
             print(e, args)
             return 1, [str(e)]


### PR DESCRIPTION
No longer fail when `self.command` cannot be found if it won't actually be used.

Fixes #53. Obsoletes #55.