### PR TITLE
Allow following imports on newer mypy daemon

### DIFF
--- a/bin/pycheckers.py
+++ b/bin/pycheckers.py
@@ -822,7 +822,7 @@ class MyPy2Runner(LintRunner):
 
         if daemon_mode:
             flags = [f for f in flags if f != '--incremental']
-            flags = ['run', '--timeout', '600', '--', '--follow-imports=error'] + flags
+            flags = ['run', '--timeout', '600', '--'] + flags
         else:
             if self.version < LooseVersion('0.660'):
                 # --quick-and-dirty is still available

--- a/bin/pycheckers.py
+++ b/bin/pycheckers.py
@@ -822,7 +822,11 @@ class MyPy2Runner(LintRunner):
 
         if daemon_mode:
             flags = [f for f in flags if f != '--incremental']
-            flags = ['run', '--timeout', '600', '--'] + flags
+            # Older daemon versions didn't support following imports
+            if self.version < LooseVersion('0.780'):
+                flags = ['run', '--timeout', '600', '--', '--follow-imports=error'] + flags
+            else:
+                flags = ['run', '--timeout', '600', '--'] + flags
         else:
             if self.version < LooseVersion('0.660'):
                 # --quick-and-dirty is still available

--- a/bin/pycheckers.py
+++ b/bin/pycheckers.py
@@ -786,8 +786,9 @@ class MyPy2Runner(LintRunner):
         r' (?P<level>[^:]+):'
         r' (?P<description>.+)$')
 
+    # Note: this needs to match both mypy and dmypy
     version_matcher = re.compile(
-        r'mypy (?P<version>[0-9.]+)'
+        r'.*mypy (?P<version>[0-9.]+)'
     )
 
     _base_flags = [

--- a/bin/pycheckers.py
+++ b/bin/pycheckers.py
@@ -788,7 +788,7 @@ class MyPy2Runner(LintRunner):
 
     # Note: this needs to match both mypy and dmypy
     version_matcher = re.compile(
-        r'.*mypy (?P<version>[0-9.]+)'
+        r'd?mypy (?P<version>[0-9.]+)'
     )
 
     _base_flags = [


### PR DESCRIPTION
In version 0.780, the mypy daemon gained support for following imports, so setting --follow-imports=error and providing all imports explicitly on the command line is no longer necessary. This updates flycheck-pycheckers' mypy daemon mode accordingly.
See https://mypy-lang.blogspot.com/2020/06/mypy-0780-released.html