### PR TITLE
Fix Python 3 support for pycheckers.py

### DIFF
--- a/bin/pycheckers.py
+++ b/bin/pycheckers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """A hacked up version of the multiple-Python checkers script from EmacsWiki.
 
 Original work taken from http://www.emacswiki.org/emacs/PythonMode, author

--- a/bin/pycheckers.py
+++ b/bin/pycheckers.py
@@ -19,7 +19,7 @@ import sys
 import time
 from argparse import ArgumentParser, ArgumentTypeError
 from csv import DictReader
-from distutils.version import LooseVersion
+from packaging.version import Version
 from functools import partial
 import shlex
 from subprocess import PIPE, Popen
@@ -145,7 +145,7 @@ class LintRunner(object):
         # The root directory of the current project
         self._project_root = None         # type: Optional[str]
         # The version of the checker, if available
-        self._version = None              # type: Optional[LooseVersion]
+        self._version = None              # type: Optional[Version]
         # Any debugging output
         self._debug_lines = []            # type: List[str]
 
@@ -224,10 +224,10 @@ class LintRunner(object):
 
     @property
     def version(self):
-        # type: () -> LooseVersion
+        # type: () -> Version
         """The version of the current checker."""
         if not self._version:
-            self._version = LooseVersion(self._get_version() or '0')
+            self._version = Version(self._get_version() or '0')
             assert self._version  # make mypy happy
         return self._version
 
@@ -630,7 +630,7 @@ class Flake8Runner(LintRunner):
         # type: (str) -> Iterable[str]
         args = []
         if self.ignore_codes is not None:
-            if self.version >= LooseVersion('3.6.0'):
+            if self.version >= Version('3.6.0'):
                 # This only works with flake8 3.6.0+, and *extends*
                 # the values given by a config file.
                 args.append('--extend-ignore=' + ','.join(self.ignore_codes))
@@ -824,12 +824,12 @@ class MyPy2Runner(LintRunner):
         if daemon_mode:
             flags = [f for f in flags if f != '--incremental']
             # Older daemon versions didn't support following imports
-            if self.version < LooseVersion('0.780'):
+            if self.version < Version('0.780'):
                 flags = ['run', '--timeout', '600', '--', '--follow-imports=error'] + flags
             else:
                 flags = ['run', '--timeout', '600', '--'] + flags
         else:
-            if self.version < LooseVersion('0.660'):
+            if self.version < Version('0.660'):
                 # --quick-and-dirty is still available
                 flags += ['--quick-and-dirty']
 


### PR DESCRIPTION
# Motivation

[Python 3?](https://github.com/msherry/flycheck-pycheckers/issues/64)

The `bin/pycheckers.py` script fails to run on a fresh install of Ubuntu 22.04. The issues are:

 - Ubuntu 22.04 no longer ships Python 2 and it only comes with `python3` command available. Since the script shebang is using `python` it fails to run;
 - After fixing the above, the script outputs deprecation warnings (`distutils.version` is deprecated) which causes the _flychecker_ to show a warning.

# Approach

The above issues are overcome if the `bin/pycheckers.py` gets migrated to Python3. Please read the issue discussion for more details.

For more details on the changes made please read the commit messages.

This PR drops support for running bin/pycheckers.py` using _Python 2_, yet it is still possible to use `bin/pycheckers.py` to lint _Python 2_ scripts.  

# Testing

These changes were tested using _emacs 28_ on Ubuntu 22.04.